### PR TITLE
Compiler Warning Refactor

### DIFF
--- a/data_structures/hash_table/hash_table.h
+++ b/data_structures/hash_table/hash_table.h
@@ -17,6 +17,10 @@
 #include <stdbool.h>
 #include "hash_node.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/linked_lists/doubly_linked_list/doubly_linked_list.h
+++ b/data_structures/linked_lists/doubly_linked_list/doubly_linked_list.h
@@ -15,6 +15,10 @@
 #include <stdlib.h>
 #include "doubly_linked_list_node.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/linked_lists/singly_linked_list/singly_linked_list.h
+++ b/data_structures/linked_lists/singly_linked_list/singly_linked_list.h
@@ -15,6 +15,10 @@
 #include <stdlib.h>
 #include "singly_linked_list_node.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/queues/deque.h
+++ b/data_structures/queues/deque.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include "../linked_lists/doubly_linked_list/doubly_linked_list.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/queues/linked_list_queue.h
+++ b/data_structures/queues/linked_list_queue.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include "../linked_lists/singly_linked_list/singly_linked_list.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/stacks/dropout_stack.h
+++ b/data_structures/stacks/dropout_stack.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include "../linked_lists/singly_linked_list/singly_linked_list.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/data_structures/stacks/linked_list_stack.h
+++ b/data_structures/stacks/linked_list_stack.h
@@ -15,6 +15,10 @@
 #include <stdbool.h>
 #include "../linked_lists/singly_linked_list/singly_linked_list.h"
 
+/************************************
+ * COMPILER DIRECTIVES
+ ************************************/
+// Added for void* to required type conversions
 #pragma GCC diagnostic ignored "-Wint-conversion"
 
 /*!

--- a/example_files/deque_test.c
+++ b/example_files/deque_test.c
@@ -15,8 +15,6 @@
 #include <stdio.h>
 #include "../data_structures/queues/deque.h"
 
-#pragma GCC diagnostic ignored "-Wint-conversion"
-
 /*!
  * @brief Prints the contents of the doubly linked list to the terminal.
  * @param list Pointer to a doubly linked list struct.


### PR DESCRIPTION
Compiler directive

 `#pragma GCC diagnostic ignored "-Wint-conversion"` 

has been added to .h files where required to suppress void* to required type conversions

